### PR TITLE
[feat] Connect to the MongoDB Atlas

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -61,4 +61,4 @@ dist/
 npm-debug.log
 yarn-error.log
 
-# End of https://www.toptal.com/developers/gitignore/api/macos,visualstudiocode,vuejs
+.env

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,9 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.20.2",
+    "dotenv": "^16.3.1",
     "express": "^4.18.2",
+    "mongoose": "^8.0.1",
     "morgan": "^1.10.0"
   }
 }

--- a/server/server.js
+++ b/server/server.js
@@ -1,10 +1,18 @@
 const express = require('express');
 const morgan = require('morgan');
 const bodyParser = require('body-parser');
+const mongoose = require('mongoose');
+const dotenv = require('dotenv');
 
-const app = express()
+dotenv.config();
 
-// Midllewares
+const app = express();
+
+mongoose.connect(process.env.DATABASE)
+  .then(() => console.log("Connected to the database"))
+  .catch(err => console.error(err));
+
+// Middlewares
 app.use(morgan('dev'));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));


### PR DESCRIPTION
- `mongoose`라이브러리를 이용한 `MongoDB`와 컨넥팅
- `callback`함수가 아닌 `promise`기반의 함수 작성
- `dotenv`라이브러리를 이용하여 `MongoDB Atlas`의 개인 연결 정보를 `.env`파일 작성 후 import해서 사용함.